### PR TITLE
[Hotfix 2024.5.15.1] Microsoft Store and ModManifestMaker Fixes

### DIFF
--- a/Client/Core/GlobalData.cs
+++ b/Client/Core/GlobalData.cs
@@ -2,6 +2,7 @@
 using HWM.Tools.Firebase.WPF.Models;
 using System.Diagnostics;
 using System.IO;
+using System.Security.Principal;
 
 namespace HWM.Tools.Firebase.WPF.Core
 {
@@ -24,17 +25,17 @@ namespace HWM.Tools.Firebase.WPF.Core
         #region Launch Commands
 
         private const string Launch_HWDE_Steam = "/C start steam://rungameid/459220";
-        private const string Launch_HWDE_MS = "/C start shell:AppsFolder\\Microsoft.BulldogThreshold_8wekyb3d8bbwe!xgameFinal";
+        private const string Launch_HWDE_MS    = "/C start shell:AppsFolder\\Microsoft.BulldogThreshold_8wekyb3d8bbwe!xgameFinal";
         public static string LaunchCommand => UserConfig.InstallationType == "Steam" ? Launch_HWDE_Steam : Launch_HWDE_MS;
 
         #endregion
 
         #region LocalAppData Info
 
-        private static readonly string LocalAppData_System = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        private static readonly string LocalAppData_Steam = Path.Combine(LocalAppData_System, "Halo Wars");
-        private static readonly string LocalAppData_MS = Path.Combine(LocalAppData_System, "Packages", "Microsoft.BulldogThreshold_8wekyb3d8bbwe", "LocalState");
-        public static DirectoryInfo LocalAppDataFolder => new(UserConfig.InstallationType == "Steam" ? LocalAppData_Steam : LocalAppData_MS);
+        private static readonly DirectoryInfo LocalAppData_System = new($"C:\\Users\\{CurrentUser}\\AppData\\Local");
+        private static readonly DirectoryInfo LocalAppData_Steam  = new(Path.Combine(LocalAppData_System.FullName, "Halo Wars"));
+        private static readonly DirectoryInfo LocalAppData_MS     = new(Path.Combine(LocalAppData_System.FullName, "Packages", "Microsoft.BulldogThreshold_8wekyb3d8bbwe", "LocalState"));
+        public static DirectoryInfo LocalAppDataFolder => UserConfig.InstallationType == "Steam" ? LocalAppData_Steam : LocalAppData_MS;
 
         #endregion
 
@@ -49,12 +50,17 @@ namespace HWM.Tools.Firebase.WPF.Core
 
         #region Other Directories
 
-        public static FileInfo ModManifestFilePath => new(Path.Combine(LocalAppDataFolder.FullName, "ModManifest.txt"));
+        public static FileInfo ModManifestFilePath        => new(Path.Combine(LocalAppDataFolder.FullName, "ModManifest.txt"));
         public static DirectoryInfo DefaultUserModsFolder => new(Path.Combine(AppDirectory.FullName, "HWDE Mods"));
-        public static DirectoryInfo ModDataFolderPath => new(Path.Combine(LocalAppDataFolder.FullName, "ModData"));
+        public static DirectoryInfo ModDataJunction       => new(Path.Combine(LocalAppDataFolder.FullName, "ModData"));
 
         #endregion
 
-        
+        #region Other Data
+
+        public static string CurrentUser => WindowsIdentity.GetCurrent().Name.Split('\\')[1];
+
+        #endregion
+
     }
 }

--- a/Client/Core/MainLaunchTasks.cs
+++ b/Client/Core/MainLaunchTasks.cs
@@ -26,11 +26,11 @@ namespace HWM.Tools.Firebase.WPF.Core
                     GlobalData.ModManifestFilePath.Delete();
 
                 // Delete any leftover ModData junctions
-                if (JunctionPoint.Exists(GlobalData.ModDataFolderPath.FullName))
-                    JunctionPoint.Delete(GlobalData.ModDataFolderPath.FullName);
+                if (JunctionPoint.Exists(GlobalData.ModDataJunction.FullName))
+                    JunctionPoint.Delete(GlobalData.ModDataJunction.FullName);
 
                 // Double check on directory cleanup
-                if (JunctionPoint.Exists(GlobalData.ModDataFolderPath.FullName) && GlobalData.ModManifestFilePath.Exists)
+                if (JunctionPoint.Exists(GlobalData.ModDataJunction.FullName) && GlobalData.ModManifestFilePath.Exists)
                     throw new IOException("An unknown error has prevented the deletion of either the ModData junction point, the ModManifest.txt file, or both.");
 
                 // All OK
@@ -68,14 +68,14 @@ namespace HWM.Tools.Firebase.WPF.Core
                 }
 
                 // Mainly for Microsoft Store distros so that data can be accessed
-                AddDirectorySecurity(GlobalData.ModDataFolderPath.FullName, SID.AllApplicationPackages, FileSystemRights.Read, AccessControlType.Allow);
+                AddDirectorySecurity(GlobalData.SelectedMod.ModDataFolder!, SID.AllApplicationPackages, FileSystemRights.Read, AccessControlType.Allow);
 
                 // Create folder junctiona and create ModManifest.txt file
-                JunctionPoint.Create(GlobalData.ModDataFolderPath.FullName, GlobalData.SelectedMod.ModDataFolder!, true);
+                JunctionPoint.Create(GlobalData.ModDataJunction.FullName, GlobalData.SelectedMod.ModDataFolder!, true);
 
                 // Create ModManifest.txt pointing to the ModData directory junction
                 using (var manifest = File.CreateText(GlobalData.ModManifestFilePath.FullName))
-                    manifest.WriteLine(GlobalData.ModDataFolderPath.FullName);
+                    manifest.WriteLine(GlobalData.ModDataJunction.FullName);
             }
             catch (Exception ex)
             {

--- a/Client/Core/Serialization/ConfigSerializer.cs
+++ b/Client/Core/Serialization/ConfigSerializer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using System.Security.Principal;
 using System.Xml;
 using System.Xml.Serialization;
 using System.IO;
@@ -39,9 +38,8 @@ namespace HWM.Tools.Firebase.WPF.Core.Serialization
 
                 if (!GlobalData.LocalAppDataFolder.Exists)
                 {
-                    var mb = MessageBox.Show("LocalAppData Folder Missing",
-                                            $"Game LocalAppData directory not found for the currently logged-in user '{WindowsIdentity.GetCurrent().Name.Split('\\')[1]}'\n\n" +
-                                            $"Please ensure that you are logged into the profile that installed the game!");
+                    var mb = MessageBox.Show($"Game LocalAppData directory not found for the currently logged-in user '{GlobalData.CurrentUser}'\n\n" +
+                                             $"Please ensure that you are logged into the profile that installed the game!", "LocalAppData Folder Missing");
 
 
                     // Delete original config and shut down

--- a/Client/Core/Versioning/AutoUpdater.cs
+++ b/Client/Core/Versioning/AutoUpdater.cs
@@ -28,9 +28,12 @@ namespace HWM.Tools.Firebase.WPF.Core.Versioning
 
             Utilities.EnsureSingleInstance();
 
-            foreach (var file in Directory.EnumerateFiles(Path.GetDirectoryName(Environment.ProcessPath!)!, "*.deleteonnextlaunch", SearchOption.TopDirectoryOnly))
-                File.Delete(file);
-            Log.Information("Old version files detected and deleted");
+            var filesToDelete = Directory.EnumerateFiles(GlobalData.AppDirectory.FullName, "*.deleteonnextlaunch", SearchOption.TopDirectoryOnly);
+            if (filesToDelete.Any())
+            {
+                foreach (var file in filesToDelete) File.Delete(file);
+                Log.Information("Old version files detected and deleted");
+            }
 
             var releaseData = GetLatestReleaseJSON();
             
@@ -42,7 +45,7 @@ namespace HWM.Tools.Firebase.WPF.Core.Versioning
 
             Log.Information($"A newer version of this mod manager is available ({GlobalData.AppVersion} --> {releaseData.tag_name}). Prompting user for input...");
             var result = MessageBox.Show($"A newer version of this mod manager is available. Would you like to update?\n\n" +
-                                        $"{GlobalData.AppVersion} --> {releaseData.tag_name}", "Update Available", MessageBoxButton.YesNo, MessageBoxImage.Information);
+                                         $"{GlobalData.AppVersion} --> {releaseData.tag_name}", "Update Available", MessageBoxButton.YesNo, MessageBoxImage.Information);
 
             // Update was denied
             if (result != MessageBoxResult.Yes)
@@ -65,7 +68,8 @@ namespace HWM.Tools.Firebase.WPF.Core.Versioning
             var newFiles = Directory.EnumerateFiles(UpdateFolderPath);
             foreach (var file in newFiles) File.Move(file, Path.Combine(GlobalData.AppDirectory.FullName, Path.GetFileName(file)));
 
-            Directory.Delete(UpdateFolderPath);
+            // Clear out update directory
+            Directory.Delete(UpdateFolderPath, true);
 
             // Start new process
             Utilities.PopToastNotification("Now Updating", "Please wait while Firebase updates. The client will restart automatically.");

--- a/Client/HWM.Tools.Firebase.Client.csproj
+++ b/Client/HWM.Tools.Firebase.Client.csproj
@@ -12,6 +12,7 @@
     <ApplicationIcon>Resources\Icon_Blagoicons.ico</ApplicationIcon>
     <PlatformTarget>x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <Company>HaloWarsModding</Company>
     <Authors>$(AssemblyName)</Authors>
     <AssemblyVersion>2024.5.15</AssemblyVersion>

--- a/ModManifestMaker/HWM.Tools.Firebase.ModManifestMaker.csproj
+++ b/ModManifestMaker/HWM.Tools.Firebase.ModManifestMaker.csproj
@@ -8,6 +8,7 @@
     <UseWPF>true</UseWPF>
     <AssemblyName>ModManifestMaker</AssemblyName>
     <PlatformTarget>x64</PlatformTarget>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyVersion>2024.5.15</AssemblyVersion>
     <RepositoryUrl>https://github.com/HaloWarsModding/Firebase</RepositoryUrl>
     <Company>HaloWarsModding</Company>

--- a/ModManifestMaker/Windows/MainWindow.xaml
+++ b/ModManifestMaker/Windows/MainWindow.xaml
@@ -40,7 +40,7 @@
                         <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding Name            , UpdateSourceTrigger=PropertyChanged}" ToolTip="The name of your mod"/>
                         <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding Author          , UpdateSourceTrigger=PropertyChanged}" ToolTip="The name of whoever made this mod"/>
                         <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding Version         , UpdateSourceTrigger=PropertyChanged}" ToolTip="The current version of your mod"/>
-                        <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding ModDataDirectory, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}" ToolTip="The directory containing your 'ModData' folder. This is where your .hwmod file will be put."/>
+                        <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding ModDataDirectory, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}" IsReadOnly="True" ToolTip="The directory containing your 'ModData' folder. This is where your .hwmod file will be put."/>
                     </StackPanel>
                     
                 </DockPanel>
@@ -56,29 +56,29 @@
                 <!-- Custom Banner Art -->
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10,0">
                     <Label Style="{StaticResource LabelStyle}" Content="Custom Banner:"/>
-                    <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding CustomBannerPath}" IsEnabled="{Binding RequiredFieldsSet}" Margin="22,5"/>
+                    <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding CustomBannerPath}" IsEnabled="{Binding EnableSaving}" Margin="22,5"/>
                 </StackPanel>
-                <Button Style="{StaticResource BrowseButtons}" IsEnabled="{Binding RequiredFieldsSet}" Command="{Binding GetCustomResourcePathCommand}" CommandParameter="Banner" Content="Browse for Custom Banner Art"/>
+                <Button Style="{StaticResource BrowseButtons}" IsEnabled="{Binding EnableSaving}" Command="{Binding GetCustomResourcePathCommand}" CommandParameter="Banner" Content="Browse for Custom Banner Art"/>
 
                 <!-- Custom Icon Art -->
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10,0">
                     <Label Style="{StaticResource LabelStyle}" Content="Custom Icon:"/>
-                    <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding CustomIconPath}" IsEnabled="{Binding RequiredFieldsSet}" Margin="22,5"/>
+                    <TextBox Style="{StaticResource TextBoxStyle}" Text="{Binding CustomIconPath}" IsEnabled="{Binding EnableSaving}" Margin="22,5"/>
                 </StackPanel>
-                <Button Style="{StaticResource BrowseButtons}" IsEnabled="{Binding RequiredFieldsSet}" Command="{Binding GetCustomResourcePathCommand}" CommandParameter="Icon" Content="Browse for Custom Icon"/>
+                <Button Style="{StaticResource BrowseButtons}" IsEnabled="{Binding EnableSaving}" Command="{Binding GetCustomResourcePathCommand}" CommandParameter="Icon" Content="Browse for Custom Icon"/>
 
                 <!-- Description -->
                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center" Margin="10,0" Width="380">
                     <Label Style="{StaticResource LabelStyle}" Content="Description:"/>
-                    <TextBox Text="{Binding Description}" IsEnabled="{Binding RequiredFieldsSet}" TextWrapping="Wrap" AcceptsReturn="True" Width="Auto" Height="160" FontSize="14" Margin="0,0,0,10"/>
+                    <TextBox Text="{Binding Description}" IsEnabled="{Binding EnableSaving}" TextWrapping="Wrap" AcceptsReturn="True" Width="Auto" Height="160" FontSize="14" Margin="0,0,0,10"/>
                 </StackPanel>
             </StackPanel>
         </GroupBox>
         
         <!-- Bottom Buttons -->
         <DockPanel LastChildFill="False">
-            <Button DockPanel.Dock="Right" Style="{StaticResource BottomButtons}" Command="{Binding GetCustomResourcePathCommand}" CommandParameter="Manifest" Content="Open Manifest" />
-            <Button DockPanel.Dock="Left"  Style="{StaticResource BottomButtons}" Content="Save Manifest" IsEnabled="{Binding RequiredFieldsSet}" />
+            <Button DockPanel.Dock="Right" Style="{StaticResource BottomButtons}" Content="Open Manifest" Command="{Binding GetCustomResourcePathCommand}" CommandParameter="Manifest" />
+            <Button DockPanel.Dock="Left"  Style="{StaticResource BottomButtons}" Content="Save Manifest" Command="{Binding SaveManifestCommand}" IsEnabled="{Binding EnableSaving}" />
         </DockPanel>
     </StackPanel>
 </Window>


### PR DESCRIPTION
Squashed Bugs:
- Fixed an issue with Firebase finding Microsoft Store installs
- Fixed an issue with Firebase not applying the correct folder security to mods when launching (affects Microsoft Store installs)
- Fixed an issue with ModManifestMaker not being able to save new manifests and not validating data correctly

General Changes:
- Tweaked build settings to publish each executable fully self-contained (no need for extra assemblies)